### PR TITLE
Add conda support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,16 @@ Here, we provide a brief description on the core funtionality of TEPIC, the comp
 If you use conda, create the required environment by running
 
     conda env create tepic -f conda.yaml
+    
+Activate the environment using
+
+    conda activate tepic
 
 Then, in the Code/ directory, compile TRAPmulti.cpp
 
     g++ TRAPmulti.cpp -O3 -fopenmp -o TRAPmulti
+    
+You can now use TEPIC.sh
 
 ### Manual installation
 To run *TEPIC* the following packages/software must be installed:

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Details on the models are provided in the respective subfolders as well as in th
 Here, we provide a brief description on the core funtionality of TEPIC, the computation of TF-gene scores. 
 
 ## Installing TEPIC
+
+### Using conda
+
+If you use conda, create the required environment by running
+
+    conda env create tepic -f conda.yaml
+
+Then, in the Code/ directory, compile TRAPmulti.cpp
+
+    g++ TRAPmulti.cpp -O3 -fopenmp -o TRAPmulti
+
+### Manual installation
 To run *TEPIC* the following packages/software must be installed:
 * Python (minimum version 2.7)
 * [bedtools](https://github.com/arq5x/bedtools2): Installation instructions for bedtools can be found [here](http://bedtools.readthedocs.io/en/latest/content/installation.html). Please make sure to add

--- a/conda.yaml
+++ b/conda.yaml
@@ -1,0 +1,18 @@
+name: TEPIC
+channels: 
+  - bioconda
+  - conda-forge
+  - r
+dependencies:
+  - compilers
+  - bedtools
+  - numpy
+  - scipy
+  - twobitreader
+  - r-gplots
+  - r-ggplot2
+  - r-glmnet
+  - r-domc
+  - r-reshape2
+  - r-gridextra
+

--- a/conda.yaml
+++ b/conda.yaml
@@ -15,4 +15,4 @@ dependencies:
   - r-domc
   - r-reshape2
   - r-gridextra
-
+  - r-data.table


### PR DESCRIPTION
When possible, I use package managers to install software. Since TEPIC is not (yet) in any of the anaconda repositories (e.g. bioconda), I added a conda environment file with instructions (in the README). 

This way, user can install the software in an isolated and reproducible environment.